### PR TITLE
Estimate Unknown Wall Types via Archetypes

### DIFF
--- a/beta_app.py
+++ b/beta_app.py
@@ -13,8 +13,7 @@ from pandas.core.series import Series
 import plotly.express as px
 import streamlit as st
 
-from dublin_energy_app.deap import calculate_heat_loss_parameter
-from dublin_energy_app import dashboard
+from dublin_energy_app import archetypes
 
 KWH_TO_MWH = 10 ** -3
 DATA_DIR = Path("./data")
@@ -69,68 +68,13 @@ def load_data(
     )
 
 
-def estimate_wall_types(
-    known_indiv_hh: DataFrame,
-    unknown_indiv_hh: DataFrame,
-    wall_archetypes: DataFrame,
-    index_columns: List[str],
-) -> DataFrame:
-    wall_type_is_known = known_indiv_hh["most_significant_wall_type"].notnull()
-    unknown_wall_types = pd.concat(
-        [
-            known_indiv_hh[~wall_type_is_known]["most_significant_wall_type"],
-            unknown_indiv_hh["most_significant_wall_type"],
-        ]
-    )
-    estimated_wall_types = (
-        unknown_wall_types.reset_index()
-        .set_index(["dwelling_type", "period_built"])
-        .combine_first(
-            wall_archetypes.rename(columns={"WallType": "most_significant_wall_type"})
-        )
-        .reset_index()
-        .set_index(INDEX_COLUMNS)
-    )
-    return pd.concat(
-        [
-            known_indiv_hh[wall_type_is_known][["most_significant_wall_type"]],
-            estimated_wall_types,
-        ]
-    )
-
-
-def show_housing_projections(esri_forecast):
-    if st.checkbox("Show Housing Demand Projections"):
-        st.subheader(
-            "Structural Housing Demand Projections By Local Authority 2017-2014"
-        )
-        st.markdown(
-            "These housing demand projections are used to estimate the housing demand in"
-            " Dublin at any given year."
-        )
-        st.markdown(
-            "*__Source__: Bergin, A. and García-Rodríguez, A., 2020."
-            " Regional demographics and structural housing demand at a county Level."
-            " ESRI, Economic & Social Research Institute.*"
-        )
-        st.write(esri_forecast)
-
-
-def show_housing_sample(stock):
-    if st.checkbox("Show Individual Housing Sample"):
-        st.markdown(
-            "This is a sample of the individual households used in the demand calculation"
-        )
-        sample = stock.sample(50).reset_index()
-
-        # NOTE: streamlit doesn't yet support st.write for categorical dtypes
-        column_dtypes = sample.dtypes.to_dict()
-        categorical_columns = {
-            k: str
-            for k, v in column_dtypes.items()
-            if isinstance(v, pd.CategoricalDtype)
-        }
-        st.write(sample.astype(categorical_columns))
+def _convert_categorical_columns_to_str(df: DataFrame) -> DataFrame:
+    # NOTE: streamlit doesn't yet support st.write for categorical dtypes
+    column_dtypes = df.dtypes.to_dict()
+    categorical_column_dtypes = {
+        k: str for k, v in column_dtypes.items() if isinstance(v, pd.CategoricalDtype)
+    }
+    return df.astype(categorical_column_dtypes)
 
 
 data_dir = Path("./data")
@@ -146,8 +90,28 @@ st.title("Dublin Housing Energy Demand App")
     esri_forecast,
 ) = load_data(data_dir, INDEX_COLUMNS)
 
-show_housing_sample(known_indiv_hh)
+if st.checkbox("Show sample of known building stock?"):
+    text = (
+        "<strong>Source:</strong> BER public geocoded to Small Area level by SEAI"
+        " (July, 2020)"
+    )
+    st.markdown(text, unsafe_allow_html=True)
+    st.write(
+        known_indiv_hh.sample(50)
+        .reset_index()
+        .pipe(_convert_categorical_columns_to_str)
+    )
 
-wall_types = estimate_wall_types(
-    known_indiv_hh, unknown_indiv_hh, wall_archetypes, INDEX_COLUMNS
+if st.checkbox("Show wall archetypes?"):
+    text = (
+        "<strong>Source:</strong> Derived from SEAI's BER public dataset (June, 2021)"
+    )
+    st.markdown(text, unsafe_allow_html=True)
+    st.write(wall_archetypes.reset_index().pipe(_convert_categorical_columns_to_str))
+
+wall_types = archetypes.estimate_type_of_wall(
+    known_indiv_hh,
+    unknown_indiv_hh,
+    wall_archetypes,
+    on=wall_archetypes.index.names,
 )

--- a/dublin_energy_app/archetypes.py
+++ b/dublin_energy_app/archetypes.py
@@ -1,0 +1,42 @@
+from typing import List
+
+import pandas as pd
+
+
+def estimate_type_of_wall(
+    known_indiv_hh: pd.DataFrame,
+    unknown_indiv_hh: pd.DataFrame,
+    wall_archetypes: pd.DataFrame,
+    on: List[str],
+) -> pd.DataFrame:
+    wall_type_is_known = known_indiv_hh["most_significant_wall_type"].notnull()
+    unknown_wall_types = pd.concat(
+        [
+            known_indiv_hh[~wall_type_is_known]["most_significant_wall_type"],
+            unknown_indiv_hh["most_significant_wall_type"],
+        ]
+    )
+    estimated_wall_types = (
+        unknown_wall_types.reset_index()
+        .set_index(on)
+        .combine_first(wall_archetypes)
+        .reset_index()
+        .set_index(known_indiv_hh.index.names)
+    )
+    return pd.concat(
+        [
+            known_indiv_hh[wall_type_is_known][["most_significant_wall_type"]].assign(
+                wall_type_is_estimated=False
+            ),
+            estimated_wall_types.assign(wall_type_is_estimated=True),
+        ]
+    )
+
+
+def estimate_wall_uvalue(
+    known_indiv_hh: pd.DataFrame,
+    unknown_indiv_hh: pd.DataFrame,
+    wall_archetypes: pd.DataFrame,
+    index_columns: List[str],
+) -> pd.DataFrame:
+    pass

--- a/tests/test_archetypes.py
+++ b/tests/test_archetypes.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from dublin_energy_app import archetypes
+
+
+def _create_index(small_area, index_names):
+    return pd.MultiIndex.from_product(
+        [[small_area], ["Semi-detached house"], ["1961 - 1970"], [1]],
+        names=index_names,
+    )
+
+
+def test_estimate_type_of_wall():
+    index_names = ["SMALL_AREA", "dwelling_type", "period_built", "category_id"]
+    known_indiv_hh_index = _create_index("000000001", index_names)
+    known_indiv_hh = pd.DataFrame(
+        {"most_significant_wall_type": ["300mm Filled Cavity"]},
+        index=known_indiv_hh_index,
+    )
+    unknown_indiv_hh_index = _create_index("000000002", index_names)
+    unknown_indiv_hh = pd.DataFrame(
+        {"most_significant_wall_type": [np.nan]},
+        index=unknown_indiv_hh_index,
+    )
+    wall_archetypes = pd.DataFrame(
+        {"most_significant_wall_type": ["Concrete Hollow Block"]},
+        index=pd.MultiIndex.from_product(
+            [["Semi-detached house"], ["1961 - 1970"]],
+            names=["dwelling_type", "period_built"],
+        ),
+    )
+    expected_output = pd.DataFrame(
+        {
+            "most_significant_wall_type": [
+                "300mm Filled Cavity",
+                "Concrete Hollow Block",
+            ],
+            "wall_type_is_estimated": [False, True],
+        },
+        index=pd.MultiIndex.from_tuples(
+            [*known_indiv_hh_index.to_list(), *unknown_indiv_hh_index.to_list()],
+            names=index_names,
+        ),
+    )
+
+    output = archetypes.estimate_type_of_wall(
+        known_indiv_hh=known_indiv_hh,
+        unknown_indiv_hh=unknown_indiv_hh,
+        wall_archetypes=wall_archetypes,
+        on=wall_archetypes.index.names,
+    )
+
+    assert_frame_equal(output, expected_output)


### PR DESCRIPTION
To enable retrofit scenario modelling of known & unknown buildings via
modular wall archetypes.  Can now slot in any wall archetype csv so long
as the building stock contains the archetype columns to estimate unknown
building wall types