### PR TITLE
Combine Wall Type & Uvalue archetyping

### DIFF
--- a/beta_app.py
+++ b/beta_app.py
@@ -158,15 +158,9 @@ if st.checkbox("Show wall archetypes?"):
         wall_type_archetypes.reset_index().pipe(_convert_categorical_columns_to_str)
     )
 
-wall_types = archetypes.estimate_type_of_wall(
-    known_indiv_hh,
-    unknown_indiv_hh,
-    wall_type_archetypes,
-    on=wall_type_archetypes.index.names,
-)
-wall_uvalue_defaults = archetypes.estimate_uvalue_of_wall(
-    known_indiv_hh,
-    unknown_indiv_hh,
-    wall_types,
-    wall_uvalue_defaults,
+wall_uvalues = archetypes.estimate_wall_properties(
+    known_indiv_hh=known_indiv_hh,
+    unknown_indiv_hh=unknown_indiv_hh,
+    wall_type_archetypes=wall_type_archetypes,
+    wall_uvalue_defaults=wall_uvalue_defaults,
 )


### PR DESCRIPTION
So operation is performed in a single function producing:
|                                                        |   wall_uvalue | most_significant_wall_type   | wall_type_is_estimated   | wall_uvalue_is_estimated   |
|:-------------------------------------------------------|--------------:|:-----------------------------|:-------------------------|:---------------------------|
| ('268039001', 'Semi-detached house', '1961 - 1970', 1) |           0.3 | 300mm filled cavity          | False                    | False                      |
| ('268039001', 'Semi-detached house', '1961 - 1970', 2) |           0.3 | 300mm filled cavity          | False                    | False                      |