### PR TITLE
Randomly select viable retrofit buildings

### DIFF
--- a/app.py
+++ b/app.py
@@ -219,6 +219,19 @@ def calculate_fabric_heat_loss(building_stock: pd.DataFrame) -> pd.Series:
     return htuse.calculate_heat_loss_per_year(heat_loss_w_k)
 
 
+def _select_buildings_to_retrofit(
+    original_uvalues: pd.Series,
+    percentage_retrofitted: float,
+    threshold_uvalue: float,
+    random_state: int = 42,
+) -> np.array:
+    where_uvalue_is_over_threshold = original_uvalues > threshold_uvalue
+    to_retrofit = original_uvalues[where_uvalue_is_over_threshold].sample(
+        frac=percentage_retrofitted, random_state=random_state
+    )
+    return original_uvalues.index.isin(to_retrofit.index)
+
+
 def _retrofit_fabric(
     percentage_retrofitted: float,
     sample_size: int,

--- a/app.py
+++ b/app.py
@@ -233,17 +233,13 @@ def _select_buildings_to_retrofit(
 
 
 def _retrofit_fabric(
-    percentage_retrofitted: float,
-    sample_size: int,
-    new_uvalue: float,
     original_uvalues: pd.Series,
+    to_retrofit: pd.Series,
+    new_uvalue: float,
 ) -> pd.Series:
-    number_retrofitted = int(percentage_retrofitted * sample_size)
-    retrofitted_uvalues = pd.Series([new_uvalue] * number_retrofitted, dtype="float32")
-    unretrofitted_uvalues = original_uvalues.iloc[number_retrofitted:]
-    return pd.concat([retrofitted_uvalues, unretrofitted_uvalues]).reset_index(
-        drop=True
-    )
+    retrofitted_uvalues = original_uvalues.copy()
+    retrofitted_uvalues.loc[to_retrofit] = new_uvalue
+    return retrofitted_uvalues
 
 
 def _estimate_cost_of_fabric_retrofits(

--- a/app.py
+++ b/app.py
@@ -266,7 +266,7 @@ def retrofit_fabric_component(
 
     percentage_retrofitted = (
         st.slider(
-            f"% of dwellings retrofitted to U-Value = {target_uvalue_default} [W/m²K]",
+            f"% of viable dwellings retrofitted to U-Value = {target_uvalue_default} [W/m²K]",
             min_value=0,
             max_value=100,
             value=0,

--- a/test_app.py
+++ b/test_app.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 import pandas as pd
 from pandas.testing import assert_frame_equal
+from pandas.testing import assert_series_equal
 import pytest
 
 import app
@@ -55,3 +56,16 @@ def test_select_buildings_to_retrofit():
         random_state=random_state,
     )
     assert_array_almost_equal(output, expected_output)
+
+
+def test_retrofit_fabric():
+    original_uvalues = pd.Series([0.13, 2.3, 0.13, 2.3], dtype="float64")
+    to_retrofit = pd.Series([False, True, False, False], dtype="bool")
+    new_uvalue = 0.13
+    expected_output = pd.Series([0.13, 0.13, 0.13, 2.3])
+    output = app._retrofit_fabric(
+        original_uvalues=original_uvalues,
+        to_retrofit=to_retrofit,
+        new_uvalue=new_uvalue,
+    )
+    assert_series_equal(output, expected_output)

--- a/test_app.py
+++ b/test_app.py
@@ -69,3 +69,14 @@ def test_retrofit_fabric():
         new_uvalue=new_uvalue,
     )
     assert_series_equal(output, expected_output)
+
+
+def test_estimate_cost_of_fabric_retrofits():
+    to_retrofit = pd.Series([False, True, False, False], dtype="bool")
+    cost = 100
+    floor_areas = pd.Series([100] * 4, dtype="int64")
+    expected_output = pd.Series([0, 10000, 0, 0])
+    output = app._estimate_cost_of_fabric_retrofits(
+        to_retrofit=to_retrofit, cost=cost, floor_areas=floor_areas
+    )
+    assert_series_equal(output, expected_output)

--- a/test_app.py
+++ b/test_app.py
@@ -1,4 +1,5 @@
-from numpy import exp
+import numpy as np
+from numpy.testing import assert_array_almost_equal
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import pytest
@@ -23,3 +24,34 @@ def test_filter_by_ber_level(selected_ber, expected_output, monkeypatch):
     building_stock = pd.DataFrame({"energy_value": [50, 200, 600]})
     output = app.filter_by_ber_level(building_stock)
     assert_frame_equal(output, expected_output)
+
+
+def test_select_buildings_to_retrofit():
+    original_uvalues = pd.Series([0.13, 2.3] * 6, dtype="float16")
+    percentage_retrofitted = 0.5
+    threshold_uvalue = 0.5
+    random_state = 42
+    expected_output = np.array(
+        [
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+        ],
+        dtype="bool",
+    )
+    output = app._select_buildings_to_retrofit(
+        original_uvalues=original_uvalues,
+        percentage_retrofitted=percentage_retrofitted,
+        threshold_uvalue=threshold_uvalue,
+        random_state=random_state,
+    )
+    assert_array_almost_equal(output, expected_output)


### PR DESCRIPTION
Refactor from select buildings 0:x and x:N to a random sample of buildings over a specified U-Value threshold as high performance buildings are unlikely to retrofit and so should be removed from consideration.  The threshold for each fabric element is editable via streamlit.

Had to refactor both retrofit uvalue replacement, retrofit costings & thus also the catchall retrofit component function to work with a new boolean series indicating the buildings selected for retrofitting